### PR TITLE
Reset default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ matrix:
     - rvm: ruby-head
       env: PUPPET_GEM_VERSION="< 4.0.0"
 notifications:
-  email: false
+  email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ matrix:
     - rvm: ruby-head
       env: PUPPET_GEM_VERSION="< 4.0.0"
 notifications:
-  email: true
+  email: false

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ A Puppet DSL `noop()` function for setting a whole scope to noop.
 
 ## Usage
 
-This is a statement function that accepts zero or one arguments. It can be called at any
+This is a statement function that accepts one optional Boolean argument. It can be called at any
 scope. Its effects will propagate into child scopes.
 
 ```puppet
 class ssh {
 
   noop()
+  include ssh::client
 
   package { 'openssh-server' :
     ensure => installed,
@@ -27,13 +28,19 @@ class ssh {
     require => Package['openssh-server'],
   }
 }
+
+class ssh::client {
+  noop(false)
+
+  file { '/etc/ssh/ssh_config':
+    ensure => file,
+  }
+}
 ```
 
-The outcome of the usage in the example above will be equivalent to setting
-`noop => true` as a default for each resource. None of the resources in
-`Class['ssh']` will be enforced.
+In the above example, none of the resources in
+`Class['ssh']` will be enforced but the resources in Class['ssh::client'] *WILL* be enforced because the default noop value is reset to false in the child's scope. Without `noop(false)` in `Class['ssh::client']`, the parent scope's default noop value would be inherited.
 
-For granular control, noop(false) will 'reset' the default inhereted noop value
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Puppet DSL `noop()` function for setting a whole scope to noop.
 
 ## Usage
 
-This is a statement function that accepts no arguments. It can be called at any
+This is a statement function that accepts zero or one arguments. It can be called at any
 scope. Its effects will propagate into child scopes.
 
 ```puppet
@@ -32,6 +32,9 @@ class ssh {
 The outcome of the usage in the example above will be equivalent to setting
 `noop => true` as a default for each resource. None of the resources in
 `Class['ssh']` will be enforced.
+
+For granular control, noop(false) will 'reset' the default inhereted noop value
+
 
 ## License
 

--- a/lib/puppet/parser/functions/noop.rb
+++ b/lib/puppet/parser/functions/noop.rb
@@ -1,5 +1,5 @@
-# Set noop to true as default for current and children scopes
-Puppet::Parser::Functions::newfunction(:noop, :doc => "Set noop default to true or false for all resources
+# Set noop to true as default for current and children scopes, or 'reset' an inherited default with noop(false)
+Puppet::Parser::Functions::newfunction(:noop, :doc => "Set noop default for all resources
   in local scope and children scopes. This can be overriden in
   child scopes, or explicitly on each resource.
   ") do |args|
@@ -8,7 +8,7 @@ Puppet::Parser::Functions::newfunction(:noop, :doc => "Set noop default to true 
     def lookupdefaults(type)
       values = super(type)
 
-      # Create a new :noop paramter with value of true for our defaults hash
+      # Create a new :noop parameter with the specified value (true/false) for our defaults hash
       noop = Puppet::Parser::Resource::Param.new(
         :name => :noop, :value => @noop_value, :source => self.source )
 

--- a/lib/puppet/parser/functions/noop.rb
+++ b/lib/puppet/parser/functions/noop.rb
@@ -1,16 +1,16 @@
 # Set noop to true as default for current and children scopes
-Puppet::Parser::Functions::newfunction(:noop, :doc => "Set noop default to true for all resources
+Puppet::Parser::Functions::newfunction(:noop, :doc => "Set noop default to true or false for all resources
   in local scope and children scopes. This can be overriden in
   child scopes, or explicitly on each resource.
   ") do |args|
-
+      @noop_value = true if (@noop_value = args[0]).nil?
   class << self
     def lookupdefaults(type)
       values = super(type)
 
       # Create a new :noop paramter with value of true for our defaults hash
       noop = Puppet::Parser::Resource::Param.new(
-        :name => :noop, :value => 'true', :source => self.source )
+        :name => :noop, :value => @noop_value, :source => self.source )
 
       # Replace whatever defaults we recieved
       values[:noop] = noop

--- a/lib/puppet/parser/functions/noop.rb
+++ b/lib/puppet/parser/functions/noop.rb
@@ -3,7 +3,7 @@ Puppet::Parser::Functions::newfunction(:noop, :doc => "Set noop default to true 
   in local scope and children scopes. This can be overriden in
   child scopes, or explicitly on each resource.
   ") do |args|
-      @noop_value = true if (@noop_value = args[0]).nil?
+      @noop_value = true if (@noop_value = args[0]).nil? or (![true, false].include? @noop_value)
   class << self
     def lookupdefaults(type)
       values = super(type)

--- a/spec/unit/puppet/parser/functions/noop_spec.rb
+++ b/spec/unit/puppet/parser/functions/noop_spec.rb
@@ -20,6 +20,17 @@ describe Puppet::Parser::Functions.function(:noop) do
 
     expect { catalog.resource('File[/tmp/foo]')[:noop] }.to be_true
   end
+  
+  it "should give every resource a default of 'noop => false when arg0 is false'" do
+    Puppet[:code] = <<-NOOPCODE
+      noop(false)
+      file {'/tmp/foo':}
+    NOOPCODE
+
+    catalog = scope.compiler.compile
+
+    expect { catalog.resource('File[/tmp/foo]')[:noop] }.to be_false
+  end
 
   it "should give every resource in child scopes a default of 'noop => true'" do
     Puppet[:code] = <<-NOOPCODE


### PR DESCRIPTION
Hi,
I ran into an issue when calling noop(), then having no way to easily reset the default in a child scope for more granular control.
This PR adds an optional arg to noop(), allowing noop(false) to clear an inherited noop default.
Anything besides noop(false) should keep the function's original behavior, so maintains backwards compatibility.  