### PR TITLE
Fix RSpec tests and update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,9 @@ end
 
 group :development, :test do
   gem 'rake'
-  gem 'rspec', "~> 2.11.0", :require => false
-  gem 'mocha', "~> 0.10.5", :require => false
+  gem 'rspec', :require => false
+  gem 'rspec-puppet', '>= 2.3.2', :require => false
+  gem 'mocha', :require => false
   gem 'puppetlabs_spec_helper', :require => false
 end
 

--- a/spec/unit/puppet/parser/functions/noop_spec.rb
+++ b/spec/unit/puppet/parser/functions/noop_spec.rb
@@ -1,5 +1,3 @@
-#! /usr/bin/env/ruby -S rspec
-
 require 'spec_helper'
 
 describe Puppet::Parser::Functions.function(:noop) do
@@ -18,13 +16,14 @@ describe Puppet::Parser::Functions.function(:noop) do
 
     catalog = scope.compiler.compile
 
-    expect { catalog.resource('File[/tmp/foo]')[:noop] }.to be_true
+    expect(catalog.resource('File[/tmp/foo]')[:noop]).to eq('true')
+
   end
 
   it "should give every resource in child scopes a default of 'noop => true'" do
     Puppet[:code] = <<-NOOPCODE
       class test {
-        file { '/tmp/test_class':}
+        file { '/tmp/foo':}
       }
       include test
       noop()
@@ -32,6 +31,7 @@ describe Puppet::Parser::Functions.function(:noop) do
 
     catalog = scope.compiler.compile
 
-    expect { catalog.resource('File[/tmp/test_class]')[:noop] }.to be_true
+    expect(catalog.resource('File[/tmp/foo]')[:noop]).to eq('true')
   end
+
 end


### PR DESCRIPTION
This fix updates the RSpec tests to work with RSpec 2.x.
Without this update the tests fail.