### PR TITLE
respect global noop setting

### DIFF
--- a/lib/puppet/parser/functions/noop.rb
+++ b/lib/puppet/parser/functions/noop.rb
@@ -9,7 +9,7 @@ Puppet::Parser::Functions::newfunction(:noop, :doc => "Set noop default for all 
       raise(Puppet::ParseError, "noop(): Requires either "+
         "no arguments or a Boolean as first argument")
     end
-    @noop_value = args[0]
+    @noop_value = args[0] | lookupvar('clientnoop')
   else
     @noop_value = true
   end


### PR DESCRIPTION
If the agent is running in noop mode, setting noop(false) will override that.
This PR uses the client's global noop setting as the false value. 