### PR TITLE
Fix a bug with resource collector overrides causing compilation failure

### DIFF
--- a/lib/puppet/functions/noop.rb
+++ b/lib/puppet/functions/noop.rb
@@ -26,6 +26,9 @@ Puppet::Functions.create_function(:noop, Puppet::Functions::InternalFunction) do
         source: source,
       )
 
+      # Adding this default fixes a corner case with resource collectors
+      @defaults[type][:noop] = noop
+
       # Replace whatever defaults we recieved
       values[:noop] = noop
       values

--- a/spec/functions/noop_spec.rb
+++ b/spec/functions/noop_spec.rb
@@ -34,4 +34,36 @@ describe 'noop' do
       expect(catalogue).to contain_file('/tmp/foo').with_noop(true)
     }
   end
+
+  context 'should work when resource collectors perform overrides' do
+    # Context: When using noop() and a resource collector to perform overrides we would fail when all these conditions were met:
+    # 1) A resource collector was defined in a child scope from the noop() call
+    # 2) The resource collector successfully collected its resource
+    # 3) The resource collector was overriding some parameter
+    # 4) This parameter was not the noop parameter
+    # 5) The noop parameter was not set as a default (e.g. File { noop => true } )
+    #
+    # This is because the resource collector internally creates a resource (which gets noop => true) and
+    # would merge it into the existing resource (which also had noop => true). The code would try to override
+    # the noop parameter but would fail.
+    let(:pre_condition) do
+      <<-EOS
+  noop()
+
+  class myclass {
+    file { "/tmp/foo": }
+
+    File <| title == "/tmp/foo" |> {
+      ensure => present,
+    }
+  }
+
+  include myclass
+EOS
+    end
+
+    it {
+      expect(catalogue).to contain_file('/tmp/foo').with_noop(true)
+    }
+  end
 end


### PR DESCRIPTION
This is a PR to fix issue #10. I ran into that problem triggering when using the apt module and started digging. 

## The short version ##

The `noop()` function adds the `noop` parameter on all resources that are created. Resource collectors create temporary resources so they can add overrides. The `noop` parameter ends up on both the collected and temporary resources which triggers override logic when they merge.

Because of the unusual nature of the `noop` parameter in this instance we hit a corner case in the override logic that raises an error. My fix is to have the `noop()` function add `noop` as a default on the resources it touches. This avoids the corner case.

## The long version ##

### Test case ###

The test case that I used was:

```puppet
noop()

class myclass {
  file { "/tmp/foo": }

  File <| title == "/tmp/foo" |> {
    ensure => present,
  }
}

include myclass
```

The error will occur when these conditions are met:

  - A resource collector was defined in a child scope below the `noop()` call
  - The resource collector successfully collected a resource
  - The resource collector was being used to override one or more parameters
  - `noop` was not one of the parameters being overridden
  - The `noop` parameter was not set via a resource default (e.g. `File { noop => true }`)

### Where the error lies ###

The specific error that we receive ("Parameter 'noop' is already set on resource") is coming from this conditional in `override_parameter`  ([source](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/parser/resource.rb#L360)):

```ruby
  # parser/resource.rb
  def override_parameter(param)
    ...
    # The parameter is already set.  Fail if they're not allowed to override it.
    unless param.source.child_of?(current.source) || param.source.equal?(current.source) && scope.is_default?(type, param.name, current.value)
      error_location_str = Puppet::Util::Errors.error_location(current.file, current.line)
      msg = if current.source.to_s == ''
              if error_location_str.empty?
                _("Parameter '%{name}' is already set on %{resource}; cannot redefine") %
                    { name: param.name, resource: ref }
              else
                _("Parameter '%{name}' is already set on %{resource} at %{error_location}; cannot redefine") %
                    { name: param.name, resource: ref, error_location: error_location_str }
              end
            else
              if error_location_str.empty?
                _("Parameter '%{name}' is already set on %{resource} by %{source}; cannot redefine") %
                    { name: param.name, resource: ref, source: current.source.to_s }
              else
                _("Parameter '%{name}' is already set on %{resource} by %{source} at %{error_location}; cannot redefine") %
                    { name: param.name, resource: ref, source: current.source.to_s, error_location: error_location_str }
              end
            end
      raise Puppet::ParseError.new(msg, param.file, param.line)
    end
    ...
  end
```

We hit this error when the following is true:
  - The new parameter returns false in `child_of?`
  - The new parameter is not overriding a resource default in scope

In practice what I saw when debugging this was:
  - The `noop` parameter was being overridden by the resource collector (unexpected!)
  - The source for both new and old `noop` parameters was the same
      - `child_of?` returns false
      - `equal?` returns true
  - The new parameter was not overriding a resource default

Because of this both clauses of the above conditional fail and we receive the error.

### Context for `noop()` and resource collectors ###

Some important pieces of context to understand why this error is occurring:

  - The `noop()` function overrides the `lookupdefaults` function to always add e.g. `noop => true` as a parameter whenever a resource is created.
  - The scope on that `noop` parameter is always the scope where `noop()` was invoked (e.g. the top-scope)
  - Resource collectors override parameters by creating a new resource and by merging this new resource into the original. ([source](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/pops/evaluator/collectors/abstract_collector.rb#L56))
  - Resource collectors override the `child_of?` function in the collector's scope to always return true ([source](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/pops/evaluator/collectors/abstract_collector.rb#L48)). This is what allows them to override parameters defined elsewhere.

### Chain of events in the bug ###

To the best of my knowledge, here is the chain of events for the above test case:

  - `noop()` fires, overriding the `lookupdefaults` function for the top scope and all child scopes
  - In the `myclass` child scope, the `/tmp/foo` file resource is parsed and created
      - `lookupdefaults` adds `noop => true` to the parameter list (with a source in the top scope)
  - In the `myclass` child scope, the resource collector fires and collects the `/tmp/foo` resource
      - It alters the source object in the `myclass` scope, overriding `child_of?` to always return true
      - It then creates a new resource and adds all of the override parameters
          - Each of these parameters have the same scope/source as the collector, so they all get the overridden `child_of?` function
          - `lookupdefaults` adds `noop => true` to the resource (with the source from the top scope; notably, `child_of?` is *not* overridden in this context)
      - This resource is merged with the original
          - Because `noop` is specified on both resources the override logic is triggered
      - The override logic checks the conditional above
          - Both the new and old parameters have a source set in the top scope.
          - Because the top scope doesn't have the `child_of?` override the first clause fails
          - Because the `noop` parameter is not specified as a default the second clause fails
      - The error is raised

### Proposed fix ###

The fix that I settled on was to add this line to the `noop()` function: 
```ruby
@defaults[type][:noop] = noop
```
This effectively ends up setting a resource default in the calling scope for each type that the `noop()` function encounters. In my test case it effectively sets:

```puppet
Class {
  noop => true,
}

File {
  noop => true,
}
```

This allows the second clause of the conditional to pass. This seemed like the simplest fix to me, but I'm open to other approaches.