### PR TITLE
Support `noop(undef)` capability, to reset noop default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.1.0
+
+**Features**
+
+- Added `noop(undef)` capability. This allows a previously defined noop default set in an outer scope to be "un-set" for an inner scope.
+
 ## Release 1.0.1
 
 **Features**

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ class ssh::client {
 
 In the above example, none of the resources in `Class['ssh']` will be enforced. The resources in Class['ssh::client'] *WILL* be enforced, because the default noop value is reset in the child's scope. Without `noop(undef)` in `Class['ssh::client']`, the parent scope's default noop value (as set with the `noop()` function) would be inherited.
 
-Another option would be to call `noop(false)` instead of `noop(undef)` in Class['ssh::client']. The difference between these two options is how the resources will behave if Puppet runs with the `--noop` setting or CLI argument. When `noop(undef)` is used to reset the noop default in Class['ssh::client'], the CLI `--noop` flag will still work to set these resources to noop. If `noop(false)` is used, however, these resources will never noop—not even when `--noop` is used on the command line.
+Another option would be to call `noop(false)` instead of `noop(undef)` in `Class['ssh::client']`. The difference between these two options is how the resources will behave if Puppet runs with the `--noop` setting or CLI argument. When `noop(undef)` is used to reset the noop default in `Class['ssh::client']`, the CLI `--noop` flag will still work to set these resources to noop. If `noop(false)` is used, however, these resources will never noop—not even when `--noop` is used on the command line.
 
 ## Class interface
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ will not work on older versions of Puppet. Time to really explore upgrading from
 
 ## Usage
 
-This is a statement function that accepts one optional Boolean argument. It can be called at any
+This is a statement function that accepts one optional Boolean or Undef argument. It can be called at any
 scope. Its effects will propagate into child scopes.
 
 ```puppet
@@ -34,7 +34,7 @@ class ssh {
 }
 
 class ssh::client {
-  noop(false)
+  noop(undef)
 
   file { '/etc/ssh/ssh_config':
     ensure => file,
@@ -42,11 +42,9 @@ class ssh::client {
 }
 ```
 
-In the above example, none of the resources in `Class['ssh']` will be enforced
-but the resources in Class['ssh::client'] *WILL* be enforced because the
-default noop value is reset to false in the child's scope. Without `noop(false)`
-in `Class['ssh::client']`, the parent scope's default noop value (as set with the `noop()`
-function) would be inherited.
+In the above example, none of the resources in `Class['ssh']` will be enforced. The resources in Class['ssh::client'] *WILL* be enforced, because the default noop value is reset in the child's scope. Without `noop(undef)` in `Class['ssh::client']`, the parent scope's default noop value (as set with the `noop()` function) would be inherited.
+
+Another option would be to call `noop(false)` instead of `noop(undef)` in Class['ssh::client']. The difference between these two options is how the resources will behave if Puppet runs with the `--noop` setting or CLI argument. When `noop(undef)` is used to reset the noop default in Class['ssh::client'], the CLI `--noop` flag will still work to set these resources to noop. If `noop(false)` is used, however, these resources will never noop—not even when `--noop` is used on the command line.
 
 ## Class interface
 

--- a/lib/puppet/functions/noop.rb
+++ b/lib/puppet/functions/noop.rb
@@ -1,7 +1,7 @@
 Puppet::Functions.create_function(:noop, Puppet::Functions::InternalFunction) do
   dispatch :noop do
     scope_param
-    optional_param 'Boolean', :value
+    optional_param 'Variant[Boolean, Undef]', :value
   end
 
   def noop(scope, value = true)
@@ -13,6 +13,10 @@ Puppet::Functions.create_function(:noop, Puppet::Functions::InternalFunction) do
     when false
       def scope.noop_default
         false
+      end
+    when nil
+      def scope.noop_default
+        nil
       end
     end
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "trlinkin-noop",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "Thomas Linkin",
   "summary": "A Puppet DSL noop function for setting a whole scope to noop.",
   "license": "Apache-2.0",

--- a/spec/functions/noop_spec.rb
+++ b/spec/functions/noop_spec.rb
@@ -9,6 +9,8 @@ describe 'noop' do
 
   it { is_expected.to run.with_params(true) }
 
+  it { is_expected.to run.with_params(nil) }
+
   it { is_expected.to run.with_params('bad_input').and_raise_error(ArgumentError) }
 
   context "should give every resource a default of 'noop => true' when no argument is passed" do
@@ -32,6 +34,14 @@ describe 'noop' do
 
     it {
       expect(catalogue).to contain_file('/tmp/foo').with_noop(true)
+    }
+  end
+
+  context "should clear every resource's noop default when the first argument is undef" do
+    let(:pre_condition) { 'noop(undef); file {"/tmp/foo":}' }
+
+    it {
+      expect(catalogue).to contain_file('/tmp/foo').without_noop
     }
   end
 


### PR DESCRIPTION
The `noop()` function is powerful because it persists a default setting through nested scope layers. Sometimes, it is useful to set an outer scope default to one value (say, `true`), but set a small inner scope default to another value (such as the already supported `false`).

This commit adds the ability to un-set a noop default at an inner-scope layer. This is useful when a user wants to do something similar to `noop(false)` inside an outer scope that has had `noop(true)` called, but wishes to preserve the full behavior of `--noop` on the command line. In that case, `noop(false)` is insufficient because that would cause `--noop` to be ignored for those resources. Individual resource-level noop parameters take precedence over a CLI --noop argument.

The new `noop(undef)` solves for this problem. It will set any enclosing scope's noop_default to nil (unsetting the default), but not affect the behavior of CLI `--noop`.


This PR contains two commits. The first commit is the functional change. The second commit is release prep work for a 1.1.0 Forge release.